### PR TITLE
Add support for building with jdk7

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -75,7 +75,9 @@
     <target name="signed" depends="-set-release-mode, -package">
         <property name="out.unaligned.file" location="${out.absolute.dir}/${ant.project.name}-release-unaligned.apk" />
         <signjar
-            keystore="${keystore.path}" alias="${keystore.alias}" storepass="${keystore.password}"
+            keystore="${keystore.path}" alias="${keystore.alias}"
+            storepass="${keystore.password}"
+            sigalg="MD5withRSA" digestalg="SHA1"
             jar="${out.packaged.file}"
             signedjar="${out.unaligned.file}"
             verbose="true"


### PR DESCRIPTION
Here is a simple pull-request to be able to build the application using the jdk-7.
This fixes the issue reported during install:

install:
     [exec] 4760 KB/s (331172 bytes in 0.067s)
     [exec]     pkg: /data/local/tmp/ti5x-release.apk
     [exec] Failure [INSTALL_PARSE_FAILED_NO_CERTIFICATES]
