### PR TITLE
Adjust the pause instruction to correspond better to real TI-59.

### DIFF
--- a/src/State.java
+++ b/src/State.java
@@ -2050,7 +2050,7 @@ public class State
             if (ProgRunningSlowly)
               {
                 Global.Disp.SetShowing(LastShowing);
-                BGTask.postDelayed(ExecuteTask, 250);
+                BGTask.postDelayed(ExecuteTask, 600);
               }
             else
               {


### PR DESCRIPTION
I did some timing and a real TI-59 is counting up to 51 in 30 seconds
with the following simple program:
- 1 = <pause> RST

The Android application was counting up to 127 in the same time. This
little delay adjustement will make the application closer to what a
real TI-59 is doing.
