### PR TITLE
Fix rounding when printing.

### DIFF
--- a/src/State.java
+++ b/src/State.java
@@ -1477,8 +1477,11 @@ public class State
                 case 3:
                 case 4:
                       {
+                        final int MaxPrec = 15; /* fudge for roundoff caused by binary versus decimal arithmetic */
                         final int ColStart = (OpNr - 1) * 5;
-                        long Contents = (long)X;
+                        final double IntPart = Math.floor(Math.abs(Arith.RoundTo(X, MaxPrec)));
+                        long Contents = (long)IntPart;
+
                         SetX(Contents); /* manual says integer part of display is discarded as a side-effect */
                         for (int i = 5;;)
                           {


### PR DESCRIPTION
The rounding was using a simple cast, we now properly use the same
code as in Int() routine.

This fixes a bug I have found while translating an old game. The printer was sometime printing a wrong characters at the end of the print slot because of rounding.
